### PR TITLE
Fixed issue with outgoing headers under the same key with fcgi

### DIFF
--- a/src/fcgi/ClientFcgi.hx
+++ b/src/fcgi/ClientFcgi.hx
@@ -223,8 +223,7 @@ class ClientFcgi extends Client
 	{
 		var s = '';
 		if ( headersOut != null )
-			for ( k in headersOut )
-				s += k + NL;
+			s = headersOut.join(NL) + NL;
 		headersOut = null;
 		return s;
 	}


### PR DESCRIPTION
Outgoing headers such as set-cookie can appear multiple times. I've switched headersOut in ClientFcgi.hx to a List instead of a Map.
