### PR TITLE
Rewrite the multipart/form-data handling under FastCGI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ haxe:
 install:
   - haxelib dev tora .
   - haxelib install --always tora.hxml
+  - haxelib install --always test/unit/unit.hxml
   - haxelib list
 
 script:
@@ -18,4 +19,8 @@ script:
   - pushd test
   -   haxe test.hxml
   -   haxe all.hxml
+  -   pushd unit
+  -     haxe unit.hxml
+  -     neko unit-tests.n
+  -   popd
   - popd

--- a/src/fcgi/MultipartParser.hx
+++ b/src/fcgi/MultipartParser.hx
@@ -1,0 +1,264 @@
+/*
+	Tora - Neko Application Server
+	Copyright (C) 2008-2017 Haxe Foundation
+
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Lesser General Public
+	License as published by the Free Software Foundation; either
+	version 2.1 of the License, or (at your option) any later version.
+
+	This library is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public
+	License along with this library; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+package fcgi;
+
+import haxe.io.Bytes;
+import neko.NativeString;
+import tora.Code;
+
+using StringTools;
+
+private enum MultipartState {
+	MBeforeFirstBoundary;
+	MAtBoundary;
+	MPartReadingHeaders;
+	MPartReadingData;
+	MFinished;
+	MMissingBoundary;
+}
+
+private typedef MultipartQueueItem = {
+	> Recipe,
+	?next:Null<MultipartQueueItem>
+}
+
+/**
+Recipe for a Tora buffer message
+**/
+typedef Recipe = {
+	code:Code,
+	buffer:Null<String>,
+	start:Int,
+	length:Int,
+}
+
+/**
+Streaming parser for multipart/form-data
+
+Based on:
+
+ - [RFC 7578](https://tools.ietf.org/html/rfc7578): Returning Values from Forms: multipart/form-data (2015)
+ - [RFC 2388](https://tools.ietf.org/html/rfc2388): Returning Values from Forms: multipart/form-data (1998/superseeded by RFC 7578)
+ - [RFC 2046](https://tools.ietf.org/html/rfc2046): Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types (1996)
+**/
+class MultipartParser {
+	public var boundary(default,null):Null<String>;  // (null <=> missing) => CError
+	public var outputSize = 1 << 16;  // default to ModNekoApi's hardcoded size
+
+	var state = MBeforeFirstBoundary;
+	var buf:Null<String>;  // might be null MBeforeFirstBoundary or when MFinished
+	var pos = 0;
+	var queue:Null<MultipartQueueItem>;
+
+	/**
+	Construct a new multipart/form-data parser
+
+	The boundary can be `null`, but will cause all calls to `read()` to raise an
+	exception.  This allows control to reach the module before the exception is
+	raised.
+	**/
+	public function new(boundary)
+	{
+		this.boundary = boundary;
+		if (boundary == null)
+			state = MMissingBoundary;
+	}
+
+	/**
+	Feed the parser more data
+
+	It is recommended to only feed the parser once it has exhausted reading from
+	previous data, to reduce the number of buffer allocations and their size.
+
+	Once MFinished, no additional data is stored.
+	**/
+	public function feed(s:String):Void
+	{
+		if (state == MFinished)
+			return;
+		if (buf != null && pos < buf.length) {
+			var curlen = buf.length - pos;
+			var b = Bytes.alloc(curlen + s.length);
+			b.blit(0, Bytes.ofData(NativeString.ofString(buf)), pos, curlen);
+			b.blit(curlen, Bytes.ofData(NativeString.ofString(s)), 0, s.length);
+			buf = NativeString.toString(b.getData());
+		} else {
+			buf = s;
+		}
+		pos = 0;
+	}
+
+	/**
+	Parse multipart/form-data
+
+	Returns a Recipe for a Tora buffer message or `null`, if more data is needed.
+	If done reading – if the closing boundary delimiter has been found – will
+	continously return `CExecute`.
+
+	If the parser was created with a missing (i.e. `null`) boundary, this always
+	raises a ('Missing boundary for multipart/form-data':String) exception.
+	**/
+	public function read():Recipe
+	{
+		while (queue == null) {
+			switch state {
+			case MBeforeFirstBoundary if (buf != null):  // buf might still be null MBeforeFirstBoundary
+				var b = buf.indexOf(boundary, pos);
+				if (b < 0)
+					return null;
+				pos = b + boundary.length;  // jump over boundary but not \r\n (or, possibly, --)
+				state = MAtBoundary;
+			case MAtBoundary if (pos + 2 <= buf.length):  // buf must have room for \r\n or --
+				if (bufMatches("--", pos)) {
+					buf = null;
+					pos = 0;
+					state = MFinished;
+				} else {
+					pos += 2;  // jump over \r\n
+					state = MPartReadingHeaders;
+				}
+			case MPartReadingHeaders:
+				var b = buf.indexOf("\r\n\r\n", pos);
+				if (b < 0)
+					return null;
+				while (pos < b && !bufMatches("content-disposition:", pos, true))
+					pos = buf.indexOf("\r\n", pos) + 2;  // jump over \r\n
+				if (pos >= b)
+					throw "Part missing a `Content-Disposition` header";
+				var filename = null, name = null;
+				while (pos < b && (name == null || filename == null)) {
+					var eq = buf.indexOf("=", pos);
+					if (eq >= 8 && bufMatches("filename", eq - 8))
+						filename = readFieldValue(CPartFilename, eq + 1, b);  // updates pos
+					else if (eq >= 8 && bufMatches("name", eq - 4))
+						name = readFieldValue(CPartKey, eq + 1, b);  // updates pos
+					else if (eq >= 0)
+						pos = eq + 1;  // jump over =
+					else
+						break;
+				}
+				if (name == null)
+					throw "Part disposition missing a `name` field";
+				if (filename != null)
+					add(filename);
+				add(name);
+				pos = b + 4;  // jump over \r\n\r\n
+				state = MPartReadingData;
+			case MPartReadingData if (pos < buf.length):  // if there's data to read already
+				var b = -1;
+				var end = pos;
+				while (end < buf.length && end - pos < outputSize) {
+					var pb = buf.indexOf("\r\n", end);  // possible boundary line ahead
+					if (pb < 0) {
+						end = buf.length;
+						break;
+					}
+					if (pb + 2 + boundary.length > buf.length) {
+						end = pb;
+						break;
+					}
+					if (bufMatches(boundary, pb + 2)) {
+						b = pb + 2;
+						end = pb;
+						break;
+					}
+					end = pb + 2;
+				}
+				while (pos < end) {
+					var len = end - pos;
+					if (len > outputSize)
+						len = outputSize;
+					add({ code:CPartData, buffer:buf, start:pos, length:len });
+					pos += len;
+				}
+				if (b >= 0) {
+					add({ code:CPartDone, buffer:null, start:0, length:0 });
+					pos = b + boundary.length;  // jump over boundary but not \r\n
+					state = MAtBoundary;
+				}
+				// we have queued messages or need more data to continue;
+				// either way, return control to the caller
+				break;
+			case MFinished:
+				add({ code:CExecute, buffer:null, start:0, length:0 });
+			case MMissingBoundary:
+				throw "Missing boundary for multipart/form-data";
+			case _:  // not enough buffered data to continue
+				return null;
+			}
+		}
+		return pop();
+	}
+
+	function pop()
+	{
+		if (queue == null)
+			return null;
+		var m = queue;
+		queue = queue.next;
+		m.next = null;
+		return m;
+	}
+
+	function add(m:MultipartQueueItem)
+	{
+		if (m.next != null)
+			throw "Assert failed: `m.next` set by caller";
+		if (queue == null) {
+			queue = m;
+		} else {
+			var last = queue;
+			while (last.next != null)
+				last = last.next;
+			last.next = m;
+		}
+	}
+
+	function readFieldValue(code:Code, startAt:Int, maxPos:Int):MultipartQueueItem
+	{
+		var quote = buf.charAt(startAt);
+		if (quote == "\"") {
+			var endAt = buf.indexOf(quote, ++startAt);
+			if (endAt < 0 && endAt > maxPos)
+				throw "Unterminated field";
+			pos = endAt + 1;
+			return { code:code, buffer:buf, start:startAt, length:(endAt - startAt) };
+		} else {
+			throw "Assert failed: unquoted field value or unexpected encoding";
+		}
+	}
+
+	function bufMatches(sub:String, at:Int, caseInsensitive=false)
+	{
+		if (buf.length - at < sub.length)
+			return false;
+		var i = 0;
+		if (caseInsensitive) {
+			while (i < sub.length && imatch(sub.fastCodeAt(i), buf.fastCodeAt(at + i))) i++;
+		} else {
+			while (i < sub.length && sub.fastCodeAt(i) == buf.fastCodeAt(at + i)) i++;
+		}
+		return i == sub.length;
+	}
+
+	static inline function imatch(a:Int, b:Int)
+		return (a >= "A".code && a <= "Z".code ? a|32 : a) == (b >= "A".code && b <= "Z".code ? b|32 : b);
+}
+

--- a/src/fcgi/MultipartParser.hx
+++ b/src/fcgi/MultipartParser.hx
@@ -152,8 +152,9 @@ class MultipartParser {
 					var eq = buf.indexOf("=", pos);
 					if (eq >= 8 && bufMatches("filename", eq - 8))
 						filename = readFieldValue(CPartFilename, eq + 1, b);  // updates pos
-					else if (eq >= 8 && bufMatches("name", eq - 4))
+					else if (eq >= 4 && bufMatches("name", eq - 4)) {
 						name = readFieldValue(CPartKey, eq + 1, b);  // updates pos
+					}
 					else if (eq >= 0)
 						pos = eq + 1;  // jump over =
 					else

--- a/test/unit/Main.hx
+++ b/test/unit/Main.hx
@@ -1,0 +1,10 @@
+class Main {
+	static function main()
+	{
+		var r = new utest.Runner();
+		r.addCase(new TestFastCgiMultipart());
+		utest.ui.Report.create(r);
+		r.run();
+	}
+}
+

--- a/test/unit/TestFastCgiMultipart.hx
+++ b/test/unit/TestFastCgiMultipart.hx
@@ -184,5 +184,16 @@ class TestFastCgiMultipart {
 		m.feed('--foo  ');  // not a boundary *line*
 		Assert.raises(m.read, String);
 	}
+
+	public function test_missing_content_disposition_or_part_name()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Type: bar\r\n\r\n');
+		Assert.raises(m.read, String);
+
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data;\r\n\r\n');
+		Assert.raises(m.read, String);
+	}
 }
 

--- a/test/unit/TestFastCgiMultipart.hx
+++ b/test/unit/TestFastCgiMultipart.hx
@@ -169,5 +169,20 @@ class TestFastCgiMultipart {
 		m.feed('--foo--');
 		Assert.raises(m.read, String);
 	}
+
+	public function test_malformed_boundary_lines()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data; name="foo"\r\n\r\nbar\r\n');
+		m.feed('--foo  ');  // not a boundary *line*
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+		Assert.same({ code:CPartData, data:"bar" }, s(m.read()));
+		Assert.same({ code:CPartDone, data:null }, s(m.read()));
+		Assert.raises(m.read, String);
+
+		var m = new MultipartParser("--foo");
+		m.feed('--foo  ');  // not a boundary *line*
+		Assert.raises(m.read, String);
+	}
 }
 

--- a/test/unit/TestFastCgiMultipart.hx
+++ b/test/unit/TestFastCgiMultipart.hx
@@ -1,0 +1,173 @@
+/*
+	Tora - Neko Application Server
+	Copyright (C) 2008-2017 Haxe Foundation
+
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Lesser General Public
+	License as published by the Free Software Foundation; either
+	version 2.1 of the License, or (at your option) any later version.
+
+	This library is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public
+	License along with this library; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+import fcgi.MultipartParser;
+import tora.Code;
+import utest.Assert;
+
+class TestFastCgiMultipart {
+	public function new() {}
+
+	// simplify a Recipe for easier comparison
+	static function s(msg:Recipe)
+	{
+		if (msg == null)
+			return null;
+		var data = msg.buffer != null ? msg.buffer.substr(msg.start, msg.length).toString() : null;
+		return { code:msg.code, data:data };
+	}
+
+	public function test_complete_flow_with_single_feeding()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('garbage\r\n--foo\r\nContent-Disposition: form-data; name="foo"\r\n\r\nbar\r\n--foo--\r\ngarbage');
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+		Assert.same({ code:CPartData, data:"bar" }, s(m.read()));
+		Assert.same({ code:CPartDone, data:null }, s(m.read()));
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+	}
+
+	public function test_multiple_parts()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data; name="foo"\r\n\r\nFOO\r\n--foo\r\n');
+		m.feed('Content-Disposition: form-data; name="bar"\r\n\r\nBAR\r\n--foo--');
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+		Assert.same({ code:CPartData, data:"FOO" }, s(m.read()));
+		Assert.same({ code:CPartDone, data:null }, s(m.read()));
+		Assert.same({ code:CPartKey, data:"bar" }, s(m.read()));
+		Assert.same({ code:CPartData, data:"BAR" }, s(m.read()));
+		Assert.same({ code:CPartDone, data:null }, s(m.read()));
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+	}
+
+	public function test_filenames()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data; name="foo"; filename="foo.png"\r\n\r\n');
+		Assert.same({ code:CPartFilename, data:"foo.png" }, s(m.read()));
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data; filename="foo.png"; name="foo"\r\n\r\n');
+		Assert.same({ code:CPartFilename, data:"foo.png" }, s(m.read()));
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+	}
+
+	public function test_linebreaks_in_disposition()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data; name="foo";\r\n  filename="foo.png"\r\n\r\n');
+		Assert.same({ code:CPartFilename, data:"foo.png" }, s(m.read()));
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+	}
+
+	public function test_part_has_content_type()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Disposition: form-data; name="foo"\r\nContent-Type: bar\r\n\r\n');
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Type: bar\r\nContent-Disposition: form-data; name="foo"\r\n\r\n');
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+	}
+
+	public function test_lowercase_header()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('garbage\r\n--foo\r\ncontent-disposition: form-data; name="foo"\r\n\r\n');
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+	}
+
+	public function test_read_data_with_buffer_breaks()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo\r\nContent-Dispo');
+		Assert.isNull(s(m.read()));
+
+		m.feed('sition: form-data; name="foo"\r\n\r\n');
+		Assert.same({ code:CPartKey, data:"foo" }, s(m.read()));
+		Assert.isNull(s(m.read()));
+
+		m.feed('bar');
+		Assert.same({ code:CPartData, data:"bar" }, s(m.read()));
+
+		Assert.isNull(s(m.read()));
+
+		m.feed('\r\n');
+		Assert.isNull(s(m.read()));
+		m.feed('-');
+		Assert.isNull(s(m.read()));
+		m.feed('-fo');
+		Assert.isNull(s(m.read()));
+		m.feed('ster');
+		Assert.same({ code:CPartData, data:"\r\n--foster" }, s(m.read()));
+
+		m.feed('\r\n--fo');
+		Assert.isNull(s(m.read()));
+		m.feed('o');
+		Assert.same({ code:CPartDone, data:null }, s(m.read()));
+
+		m.feed('--');
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+	}
+
+	public function test_no_parts()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo--');
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+	}
+
+	public function test_before_first_boundary()
+	{
+		var m = new MultipartParser("--foo");
+		Assert.isNull(s(m.read()));
+
+		m.feed('garbage\r\n');
+		Assert.isNull(s(m.read()));
+
+		m.feed('--foo--');
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+	}
+
+	public function test_after_last_one()
+	{
+		var m = new MultipartParser("--foo");
+		m.feed('--foo--');
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+
+		// feed: don't store any data
+		m.feed("foo");
+		Assert.isNull(@:privateAccess m.buf);
+
+		// read: return CExecute, no matter what
+		Assert.same({ code:CExecute, data:null }, s(m.read()));
+	}
+
+	public function test_missing_boundary()
+	{
+		var m = new MultipartParser(null);
+		Assert.raises(m.read, String);
+		m.feed('--foo--');
+		Assert.raises(m.read, String);
+	}
+}
+

--- a/test/unit/unit.hxml
+++ b/test/unit/unit.hxml
@@ -1,0 +1,8 @@
+-lib utest
+-cp .
+-cp ../../
+-cp ../../src
+-lib hx3compat
+-main Main
+-neko unit-tests.n
+


### PR DESCRIPTION
This reimplements and optimizes the `ClientFcgi` handling of `CQueryMultipart` messages in FastCGI mode,

 - processing multipart/form-data lazily and incrementally,
 - keeping the number and size of string allocations to a minimum,
 - and placing it into a separate module.

FastCGI multipart/form-data will be processed until the first `STDIN` message is received, at which point control will be handled to the application.  Processing will resume after the application calls `neko.Web.parseMultipart`.

This follows the behavior of `mod_neko` and `mod_tora`.

To compensate for the increased complexity, there are also some unit tests.

This PR also incorporates and closes #10; for the record, lower-case headers seem to be sent by some React-Native apps.


## Motivation

This PR solves some issues my team and I experienced on a production service that used tora + FastCGI to handle uploads of reasonably sized files.

In comparison with current tora, our requirements were to:

 - **don't error (don't trigger the OOM killer and don't timeout) on large requests**
 - reduce response times for file uploads
 - check for authentication _before_ processing possibly large amounts of data
 - allow the application to more meaningfully measure its response time
 - reduce heap size and fragmentation


## Real world test results

A 7.9 MiB POST outlines the improvements:

metric | before | after
---|---|---
time in application space | 67 ms | 145 ms
time to first byte of response | 626 ms | 148 ms
`neko.vm.Gc.stats()` | 72 MiB (65 MiB used) | 6 MiB (5 MiB used)

but a larger 39 MiB POST makes this PR essential:

metric | before | after
---|---|---
time in application space | 307 ms | 667 ms
time to first byte of response | 12780 ms | 676 ms
`neko.vm.Gc.stats()` | 3970 MiB (3000 MiB used) | 6 MiB (6 MiB used)

And file sizes greater than 100 MiB generally caused the old (`master`) tora to be terminated by the OOM killer (after nearly exhausting all available memory + swap); in the rare case the request completed, Nginx or the client would have already timed out.

Note: the time spent in application space increases with this patch, but that is actually the desired: we're no longer pre-processing a lot of data before starting and handling control to the application.

---

Metrics:

 - time in application space: time from start to end of the cached entry point of the application (i.e. neko module loaded by tora)
 - time to first byte of response: response (first byte) time perceived by local client (Chrome 61)
 - heap/GC statistics from `neko.vm.Gc.stats()`, pretty printed

Test case:

 - actual route from a real world project
 - uploads of reasonably sized files with `multipart/form-data`
 - tora application hashes and writes (to disk) file content
 - application version: (closed source) jonasmalacofilho/proto-ead@a51e1ec, "dev" build

Configuration:

 - warm tora: application module cached first with a GET (application calls `neko.Web.cacheModule`)
 - heap size before POST: 4 MiB
 - locally served with Linux 4.12.13 and Nginx 1.12.2 to Chrome 61.0
 - haxe 4.0.0 (HaxeFoundation/haxe@2a16e091d) and neko 2.1.0 (HaxeFoundation/neko@597288ea59cf8500a890d151cc0a3f3f48fe89e6, built for x86-64)
 - tora: before (`master`: 6560e82) vs. after (#15: 9649ca0)
 - running on: Intel Sandy Bridge i7-2860QM + 16 GiB DDR3 + SSD
