### PR TITLE
Fix ClientFcgi

### DIFF
--- a/src/fcgi/ClientFcgi.hx
+++ b/src/fcgi/ClientFcgi.hx
@@ -250,7 +250,7 @@ class ClientFcgi extends Client
 				return next.code;
 			}
 		}
-		return null;
+		return CExecute;
 	}
 
 	override public function processMessage( ) : Bool


### PR DESCRIPTION
fix exception "Invalid field access : index" raised after calling parseMultipart on non-multipart request

Exception raised on calling `neko.Web.getMultipart` or `neko.Web.parseMultipart`